### PR TITLE
Fixes #8: Puppet incorrectly identifies module mismatch

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -160,10 +160,12 @@ define jenkins::plugin(
 
     if $digest_string {
       $checksum_verify = true
-      $checksum = $digest_string
+      $checksum        = $digest_string
+      $checksum_type   = $digest_type
     } else {
       $checksum_verify = false
-      $checksum = undef
+      $checksum        = undef
+      $checksum_type   = undef
     }
 
     archive { $plugin:
@@ -171,7 +173,7 @@ define jenkins::plugin(
       path            => "${::jenkins::plugin_dir}/${plugin}",
       checksum_verify => $checksum_verify,
       checksum        => $checksum,
-      checksum_type   => $digest_type,
+      checksum_type   => $checksum_type,
       proxy_server    => $::jenkins::proxy_server,
       cleanup         => false,
       extract         => false,


### PR DESCRIPTION
This change allows puppet to only update plugins which have changed instead of reinstalling each puppet run.

Upstream fix from voxpupuli/puppet-archive#242

Puppet run on jenkins significantly faster in my lab.  Security can also be improved by setting info like:
```
-  name: ace-editor
   version: 1.0.1
   digest_string: '281d5a741732f6743eb4ab27268d5939ed01811d'
```